### PR TITLE
Update rectify-maps.R

### DIFF
--- a/R/rectify-maps.R
+++ b/R/rectify-maps.R
@@ -281,7 +281,7 @@ get_num_components <- function (img)
             index <- index [c (1, which (diff (index) == 1) + 1)]
             dn [index] <- -1 # arbitrary negative value for next step
         }
-        if (all (dn < 0))
+        if (all (dn <= 0))
             thr0 <- thr [which.min (dn)] # in case no local min
         else
             thr0 <- thr [which (dn > 0) [1]]


### PR DESCRIPTION
Add `<=` to line 284.

From what I can tell, if `dn` contains negative and zero values then `thr0` is set to `NA`. This fixes that. 