### PR TITLE
Issue33

### DIFF
--- a/R/generate-maps.R
+++ b/R/generate-maps.R
@@ -80,7 +80,7 @@ get_raster_brick <- function (bbox, max_tiles = 16L, style)
     }
 
     out <- fast_merge (br)
-    raster::projection (out) <- "+proj=merc +a=6378137 +b=6378137"
+    raster::projection (out) <- .sph_merc() ## "+proj=merc +a=6378137 +b=6378137"
     out <- raster::crop (out, tiles$extent, snap = "out")
     if (!style == "light") # then convert to black & white
     {
@@ -175,8 +175,8 @@ slippy_bbox <- function (bbox)
 
     afun <- function (aa)
         stats::approx (seq_along (aa), aa, n = 180L)$y
-    srcproj <- "+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0"
-    crs <- "+proj=merc +a=6378137 +b=6378137"
+    srcproj <- .lonlat() #"+proj=longlat +datum=WGS84 +no_defs +ellps=WGS84 +towgs84=0,0,0"
+    crs <- .sph_merc() # "+proj=merc +a=6378137 +b=6378137"
     ex <- cbind (afun (xy [, 1L]), afun (xy [, 2L])) %>%
         reproj::reproj (target = crs, source = srcproj)
     ex <- raster::extent (ex [, 1:2])
@@ -333,7 +333,8 @@ spherical_mercator <- function (provider = "mapbox")
     res <- tibble::tibble (provider = provider,
                            maxextent = 20037508.342789244,
                            A = 6378137.0, B = 6378137.0,
-                           crs = glue::glue("+proj=merc +a={A} +b={A}"))
+                           crs = .sph_merc())  ## hardcoded, not using the A,B
+                           #crs = glue::glue("+proj=merc +a={A} +b={A}"))
     res [, res$provider == provider]
 }
 

--- a/R/generate-maps.R
+++ b/R/generate-maps.R
@@ -80,7 +80,9 @@ get_raster_brick <- function (bbox, max_tiles = 16L, style)
     }
 
     out <- fast_merge (br)
-    raster::projection (out) <- .sph_merc() ## "+proj=merc +a=6378137 +b=6378137"
+    #raster::projection (out) <- .sph_merc() ## "+proj=merc +a=6378137 +b=6378137"
+    out@crs@projargs <- .sph_merc()  ## no churn through mill
+
     out <- raster::crop (out, tiles$extent, snap = "out")
     if (!style == "light") # then convert to black & white
     {
@@ -116,7 +118,7 @@ map_to_pdf <- function (my_map, file)
                                    title = fname, file = file)      # nocov
         }
     })
-    raster::plotRGB (my_map)
+    suppressWarnings(raster::plotRGB (my_map))  ## #33
     grDevices::graphics.off ()
 
     invisible (file)
@@ -139,7 +141,7 @@ map_to_png <- function (my_map, file)
     }
 
     grDevices::png (file = file, width = w, height = h, units = "px")
-    raster::plotRGB (my_map)
+   suppressWarnings(raster::plotRGB (my_map))  ## #33
     grDevices::graphics.off ()
 
     # Then read in png, attach comment containing bbox, and re-save

--- a/R/rectify-maps.R
+++ b/R/rectify-maps.R
@@ -311,7 +311,7 @@ check_img_sanity <- function (img)
 rectify_channel <- function (channel, original, type, n = 10,
                              concavity, length_threshold, quiet = TRUE)
 {
-    crs_from <- "+proj=merc +a=6378137 +b=6378137"
+    crs_from <- .sph_merc() # "+proj=merc +a=6378137 +b=6378137"
     crs_to <- 4326
 
     bbox <- bbox_from_png (original)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,13 @@
+# sf::st_crs(4326)$proj4string
+# testepsg -e "EPSG:4326"
+# testepsg -e "EPSG:3857"
+
+.sph_merc <- function() {
+  ## https://github.com/ropensci/mapscanner/issues/33
+  "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs"
+}
+
+.lonlat <- function() {
+  "+proj=longlat +datum=WGS84 +no_defs"
+
+}

--- a/tests/testthat/test-generate.R
+++ b/tests/testthat/test-generate.R
@@ -12,6 +12,7 @@ test_that("generate", {
               #x <- ms_generate_map (loc, max_tiles = 1L, mapname = "omaha")
               #saveRDS (x, "tests/x.Rds")
               expect_silent (x <- readRDS ("../x.Rds"))
+              x@crs@projargs <- .sph_merc()
               expect_error (x <- ms_generate_map (raster_brick = x),
                             paste0 ("Please provide a 'mapname' ",
                                     "\\(with optional path\\)"))


### PR DESCRIPTION
To address #33 

 I bundled in two commits

1. adds functions to return the correct (we think) proj strings
2. wraps plotRGB to suppress warnings from sp (they are not meaningful afaict), and sets the crs text in-place 

* there is a literal instance in the vignette (line 208) which has a hardcoded raster output - that I haven't changed
* the test object x.Rds perhaps should be updated, I make the test hardcode the correct (we think) mercator crs

There's still a test error about messages, but I can't get those message to be visible (??)

```
test-file-manip.R:14: failure: file manipulation
`ms_rotate_map(f_orig, f_modified)` produced messages.
```

